### PR TITLE
Changed Artion smart contracts - factories and FantomAuction

### DIFF
--- a/contracts/FantomArtFactory.sol
+++ b/contracts/FantomArtFactory.sol
@@ -8,6 +8,7 @@ import "./FantomArtTradable.sol";
 contract FantomArtFactory is Ownable {
     /// @dev Events of the contract
     event ContractCreated(address creator, address nft);
+    event ContractDisabled(address caller, address nft);
 
     /// @notice Fantom marketplace contract address;
     address public marketplace;
@@ -26,6 +27,8 @@ contract FantomArtFactory is Ownable {
 
     /// @notice NFT Address => Bool
     mapping(address => bool) public exists;
+
+    bytes4 private constant INTERFACE_ID_ERC1155 = 0xd9b67a26;
 
     /// @notice Contract constructor
     constructor(
@@ -117,5 +120,28 @@ contract FantomArtFactory is Ownable {
         nft.transferOwnership(_msgSender());
         emit ContractCreated(_msgSender(), address(nft));
         return address(nft);
+    }
+
+    /// @notice Method for registering existing FantomArtTradable contract
+    /// @param  tokenContractAddress Address of NFT contract
+    function registerTokenContract(address tokenContractAddress)
+        external
+        onlyOwner
+    {
+        require(!exists[tokenContractAddress], "Art contract already registered");
+        require(IERC165(tokenContractAddress).supportsInterface(INTERFACE_ID_ERC1155), "Not an ERC1155 contract");
+        exists[tokenContractAddress] = true;
+        emit ContractCreated(_msgSender(), tokenContractAddress);
+    }
+
+    /// @notice Method for disabling existing FantomArtTradable contract
+    /// @param  tokenContractAddress Address of NFT contract
+    function disableTokenContract(address tokenContractAddress)
+        external
+        onlyOwner
+    {
+        require(exists[tokenContractAddress], "Art contract is not registered");
+        exists[tokenContractAddress] = false;
+        emit ContractDisabled(_msgSender(), tokenContractAddress);
     }
 }

--- a/contracts/FantomArtFactoryPrivate.sol
+++ b/contracts/FantomArtFactoryPrivate.sol
@@ -8,6 +8,7 @@ import "./FantomArtTradablePrivate.sol";
 contract FantomArtFactoryPrivate is Ownable {
     /// @dev Events of the contract
     event ContractCreated(address creator, address nft);
+    event ContractDisabled(address caller, address nft);
 
     /// @notice Fantom marketplace contract address;
     address public marketplace;
@@ -26,6 +27,8 @@ contract FantomArtFactoryPrivate is Ownable {
 
     /// @notice NFT Address => Bool
     mapping(address => bool) public exists;
+
+    bytes4 private constant INTERFACE_ID_ERC1155 = 0xd9b67a26;
 
     /// @notice Contract constructor
     constructor(
@@ -117,5 +120,28 @@ contract FantomArtFactoryPrivate is Ownable {
         nft.transferOwnership(_msgSender());
         emit ContractCreated(_msgSender(), address(nft));
         return address(nft);
+    }
+
+    /// @notice Method for registering existing FantomArtTradable contract
+    /// @param  tokenContractAddress Address of NFT contract
+    function registerTokenContract(address tokenContractAddress)
+        external
+        onlyOwner
+    {
+        require(!exists[tokenContractAddress], "Art contract already registered");
+        require(IERC165(tokenContractAddress).supportsInterface(INTERFACE_ID_ERC1155), "Not an ERC1155 contract");
+        exists[tokenContractAddress] = true;
+        emit ContractCreated(_msgSender(), tokenContractAddress);
+    }
+
+    /// @notice Method for disabling existing FantomArtTradable contract
+    /// @param  tokenContractAddress Address of NFT contract
+    function disableTokenContract(address tokenContractAddress)
+        external
+        onlyOwner
+    {
+        require(exists[tokenContractAddress], "Art contract is not registered");
+        exists[tokenContractAddress] = false;
+        emit ContractDisabled(_msgSender(), tokenContractAddress);
     }
 }

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -456,8 +456,7 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             } else {
                 IERC20 payToken = IERC20(auction.payToken);
                 require(
-                    payToken.transferFrom(
-                        address(this),
+                    payToken.transfer(
                         platformFeeRecipient,
                         platformFeeAboveReserve
                     ),
@@ -489,7 +488,7 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             } else {
                 IERC20 payToken = IERC20(auction.payToken);
                 require(
-                    payToken.transferFrom(address(this), minter, royaltyFee),
+                    payToken.transfer(minter, royaltyFee),
                     "failed to send the owner their royalties"
                 );
             }
@@ -509,8 +508,7 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
                 } else {
                     IERC20 payToken = IERC20(auction.payToken);
                     require(
-                        payToken.transferFrom(
-                            address(this),
+                        payToken.transfer(
                             minter,
                             royaltyFee
                         ),
@@ -532,8 +530,7 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             } else {
                 IERC20 payToken = IERC20(auction.payToken);
                 require(
-                    payToken.transferFrom(
-                        address(this),
+                    payToken.transfer(
                         auction.owner,
                         payAmount
                     ),

--- a/contracts/FantomNFTFactory.sol
+++ b/contracts/FantomNFTFactory.sol
@@ -8,6 +8,7 @@ import "./FantomNFTTradable.sol";
 contract FantomNFTFactory is Ownable {
     /// @dev Events of the contract
     event ContractCreated(address creator, address nft);
+    event ContractDisabled(address caller, address nft);
 
     /// @notice Fantom auction contract address;
     address public auction;
@@ -30,6 +31,8 @@ contract FantomNFTFactory is Ownable {
     /// @notice NFT Address => Bool
     mapping(address => bool) public exists;
 
+    bytes4 private constant INTERFACE_ID_ERC721 = 0x80ac58cd;
+    
     /// @notice Contract constructor
     constructor(
         address _auction,
@@ -132,5 +135,28 @@ contract FantomNFTFactory is Ownable {
         nft.transferOwnership(_msgSender());
         emit ContractCreated(_msgSender(), address(nft));
         return address(nft);
+    }
+
+    /// @notice Method for registering existing FantomNFTTradable contract
+    /// @param  tokenContractAddress Address of NFT contract
+    function registerTokenContract(address tokenContractAddress)
+        external
+        onlyOwner
+    {
+        require(!exists[tokenContractAddress], "NFT contract already registered");
+        require(IERC165(tokenContractAddress).supportsInterface(INTERFACE_ID_ERC721), "Not an ERC721 contract");
+        exists[tokenContractAddress] = true;
+        emit ContractCreated(_msgSender(), tokenContractAddress);
+    }
+
+    /// @notice Method for disabling existing FantomNFTTradable contract
+    /// @param  tokenContractAddress Address of NFT contract
+    function disableTokenContract(address tokenContractAddress)
+        external
+        onlyOwner
+    {
+        require(exists[tokenContractAddress], "NFT contract is not registered");
+        exists[tokenContractAddress] = false;
+        emit ContractDisabled(_msgSender(), tokenContractAddress);
     }
 }

--- a/contracts/FantomNFTFactoryPrivate.sol
+++ b/contracts/FantomNFTFactoryPrivate.sol
@@ -8,6 +8,7 @@ import "./FantomNFTTradablePrivate.sol";
 contract FantomNFTFactoryPrivate is Ownable {
     /// @dev Events of the contract
     event ContractCreated(address creator, address nft);
+    event ContractDisabled(address caller, address nft);
 
     /// @notice Fantom auction contract address;
     address public auction;
@@ -29,6 +30,8 @@ contract FantomNFTFactoryPrivate is Ownable {
 
     /// @notice NFT Address => Bool
     mapping(address => bool) public exists;
+
+    bytes4 private constant INTERFACE_ID_ERC721 = 0x80ac58cd;
 
     /// @notice Contract constructor
     constructor(
@@ -132,5 +135,28 @@ contract FantomNFTFactoryPrivate is Ownable {
         nft.transferOwnership(_msgSender());
         emit ContractCreated(_msgSender(), address(nft));
         return address(nft);
+    }
+
+    /// @notice Method for registering existing FantomNFTTradable contract
+    /// @param  tokenContractAddress Address of NFT contract
+    function registerTokenContract(address tokenContractAddress)
+        external
+        onlyOwner
+    {
+        require(!exists[tokenContractAddress], "NFT contract already registered");
+        require(IERC165(tokenContractAddress).supportsInterface(INTERFACE_ID_ERC721), "Not an ERC721 contract");
+        exists[tokenContractAddress] = true;
+        emit ContractCreated(_msgSender(), tokenContractAddress);
+    }
+
+    /// @notice Method for disabling existing FantomNFTTradable contract
+    /// @param  tokenContractAddress Address of NFT contract
+    function disableTokenContract(address tokenContractAddress)
+        external
+        onlyOwner
+    {
+        require(exists[tokenContractAddress], "NFT contract is not registered");
+        exists[tokenContractAddress] = false;
+        emit ContractDisabled(_msgSender(), tokenContractAddress);
     }
 }


### PR DESCRIPTION
Added functions to allow factory owner register and disable contracts into factory.
Using function transfer instead of transferFrom when sending tokens from FantomAuction contract