### PR TITLE
shitty PR for showing the concept

### DIFF
--- a/contracts/FantomAddressRegistry.sol
+++ b/contracts/FantomAddressRegistry.sol
@@ -38,6 +38,9 @@ contract FantomAddressRegistry is Ownable {
     /// @notice FantomPriceFeed contract
     address public priceFeed;
 
+    /// @notice FantomNFTOracle contract
+    address public nftOracle;
+
     /**
      @notice Update artion contract
      @dev Only admin
@@ -129,5 +132,13 @@ contract FantomAddressRegistry is Ownable {
      */
     function updatePriceFeed(address _priceFeed) external onlyOwner {
         priceFeed = _priceFeed;
+    }
+
+    /**
+     @notice Update nft oracle contract
+     @dev Only admin
+     */
+    function updateNftOracle(address _nftOracle) external onlyOwner {
+        nftOracle = _nftOracle;
     }
 }

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -549,6 +549,8 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         IFantomBundleMarketplace(addressRegistry.bundleMarketplace())
             .validateItemSold(_nftAddress, _tokenId, uint256(1));
 
+        INFTOracle(oracle).setPrice(_nftAddress, _tokenId, auction.payToken, winningBid);
+
         emit AuctionResulted(
             _nftAddress,
             _tokenId,

--- a/contracts/FantomMarketplace.sol
+++ b/contracts/FantomMarketplace.sol
@@ -508,6 +508,8 @@ contract FantomMarketplace is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         IFantomBundleMarketplace(addressRegistry.bundleMarketplace())
             .validateItemSold(_nftAddress, _tokenId, listedItem.quantity);
 
+        INFTOracle(oracle).setPrice(_nftAddress, _tokenId, _payToken, price.div(listedItem.quantity));
+
         emit ItemSold(
             _owner,
             _msgSender(),
@@ -648,6 +650,9 @@ contract FantomMarketplace is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         }
         IFantomBundleMarketplace(addressRegistry.bundleMarketplace())
             .validateItemSold(_nftAddress, _tokenId, offer.quantity);
+
+        INFTOracle(oracle).setPrice(_nftAddress, _tokenId, address(offer.payToken), offer.pricePerItem);
+
         delete (listings[_nftAddress][_tokenId][_msgSender()]);
         delete (offers[_nftAddress][_tokenId][_creator]);
 

--- a/contracts/FantomNFTOracle.sol
+++ b/contracts/FantomNFTOracle.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+contract FantomNFTOracle is OwnableUpgradeable {
+
+    /// @notice Address registry
+    IFantomAddressRegistry public addressRegistry;
+
+    // NFT address => token ID => Price
+    mapping(address => mapping(uint256 => uint256)) public price;
+    mapping(address => uint256) public floorPrice;
+
+    modifier onlySystem() {
+        require(_msgSender() == addressRegistry.auction()
+            || _msgSender() == addressRegistry.marketplace(),
+            "only system"
+        );
+        _;
+    }
+
+    /// @notice Contract initializer
+    function initialize(address _auction)
+        public
+        initializer
+    {
+        require(
+            _platformFeeRecipient != address(0),
+            "FantomAuction: Invalid Platform Fee Recipient"
+        );
+
+        platformFeeRecipient = _platformFeeRecipient;
+        emit FantomAuctionContractDeployed();
+
+        __Ownable_init();
+        __ReentrancyGuard_init();
+    }
+
+    /**
+     @notice Gets NFT price or returns floor price if no price has been recorded
+     @param _nftAddress ERC 721 Address
+     @param _tokenId Token ID of the NFT
+     @return address in what token the price is denominated in
+     @return uint256 last sold token amount
+     */
+    function getPrice(address _nftAddress, uint256 _tokenId) public view returns (uint256) {
+        if (price[_nftAddress][_tokenId] == 0) { // fallback on floor price
+            return getFloorPrice(_nftAddress);
+        }
+        return price[_nftAddress][_tokenId];
+    }
+
+    function getFloorPrice(address _nftAddress) public view returns (uint256) {
+        return floorPrice[_nftAddress];
+    }
+
+    function setPrice(address _nftAddress, uint256 _tokenId, uint256 _amount) external onlySystem {
+        price[_nftAddress][_tokenId] = _amount;
+        _refreshFloorPrice(_nftAddress, _tokenId, _amount);
+    }
+
+    function _refreshFloorPrice(address _nftAddress, uint256 _tokenId, uint256 _amount) internal {
+        // TODO
+    }
+
+    //////////
+    // Admin /
+    //////////
+
+    /**
+     @notice Update FantomAddressRegistry contract
+     @dev Only admin
+     */
+    function updateAddressRegistry(address _registry) external onlyOwner {
+        addressRegistry = IFantomAddressRegistry(_registry);
+    }
+}


### PR DESCRIPTION
This is for discussion only:

What do you think about adding onchain NFT oracle that will store latest (or maybe even historic) prices for each sold NFT. It requires oracle contract to store all prices for everyone to easily read. This helps new wave of NFT related dapps to access very simple and reliable price data.