### PR TITLE
Update FantomAuction.sol

### DIFF
--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -141,6 +141,9 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice global platform fee, assumed to always be to 1 decimal place i.e. 25 = 2.5%
     uint256 public platformFee = 25;
 
+    /// @notice Used to track and set the maximum allowed auction time (_startTimestamp + maxAuctionLength)
+    uint256 public constant maxAuctionLength = 30 days; 
+
     /// @notice where to send platform fee funds to
     address payable public platformFeeRecipient;
 
@@ -219,10 +222,10 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             "invalid pay token"
         );
 
-        // Adds hard limits to ensure the auction is <= 30 days long in total
+        // Adds hard limits to cap the maximum auction length
         require(
-            _endTimestamp <= (_startTimestamp + 30 days),
-            "Auction end date is too long"
+            _endTimestamp <= (_startTimestamp + maxAuctionLength),
+            "Auction time exceeds maximum length"
         );
 
         _createAuction(

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -310,6 +310,13 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             _bidAmount >= minBidRequired,
             "failed to outbid highest bidder"
         );
+
+        // Ensure this contract is the owner of the item
+        require(
+            IERC721(_nftAddress).ownerOf(_tokenId) == address(this),
+            "address(this) must be the item owner"
+        );
+
         if (auction.payToken != address(0)) {
             IERC20 payToken = IERC20(auction.payToken);
             require(

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -297,18 +297,34 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         _placeBid(_nftAddress, _tokenId, _bidAmount);
     }
 
+
+    /**
+     @notice Internal method doing the heavy lifting of placing a bid on an existing auction
+     @param _nftAddress ERC 721 Address
+     @param _tokenId Token ID of the NFT being auctioned
+     @param _bidAmount Bid amount
+     */
     function _placeBid(
         address _nftAddress,
         uint256 _tokenId,
         uint256 _bidAmount
     ) internal whenNotPaused {
         Auction storage auction = auctions[_nftAddress][_tokenId];
+
         // Ensure bid adheres to outbid increment and threshold
         HighestBid storage highestBid = highestBids[_nftAddress][_tokenId];
+
         uint256 minBidRequired = highestBid.bid.add(minBidIncrement);
+
         require(
             _bidAmount >= minBidRequired,
             "failed to outbid highest bidder"
+        );
+
+        // Ensures the placed bid is greater than zero
+        require(
+            msg.value > 0,
+            "Bid must be greater than zero"
         );
 
         // Ensure this contract is the owner of the item

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -641,16 +641,24 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
                 _msgSender() == auction.owner,
             "sender must be owner"
         );
-        // Check auction is real
-        require(auction.endTime > 0, "no auction exists");
-        // Check auction not already resulted
-        require(!auction.resulted, "auction already resulted");
 
-        // Gets info on auction and ensures auction has no bids before cancelling
+        // Check auction is real
+        require(
+            auction.endTime > 0, 
+            "no auction exists"
+        );
+
+        // Check auction not already resulted
+        require(
+            !auction.resulted, 
+            "auction already resulted"
+        );
+
+        // Gets info on auction and ensures highest bid is less than the reserve price
         HighestBid storage highestBid = highestBids[_nftAddress][_tokenId];
         require(
-            highestBid.bidder == address(0),
-            "Auction currently has active bids"
+            highestBid.bid < auction.reservePrice,
+            "Highest bid is currently above reserve price"
         );
 
         _cancelAuction(_nftAddress, _tokenId);

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -62,6 +62,13 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
     event PauseToggled(bool isPaused);
 
+    event UpdateAuctionReservePrice(
+        address indexed nftAddress,
+        uint256 indexed tokenId,
+        address payToken,
+        uint256 reservePrice
+    );
+
     event AuctionCreated(
         address indexed nftAddress,
         uint256 indexed tokenId,
@@ -671,6 +678,58 @@ contract FantomAuction is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     function toggleIsPaused() external onlyOwner {
         isPaused = !isPaused;
         emit PauseToggled(isPaused);
+    }
+
+    /**
+     @notice Update the current reserve price for an auction
+     @dev Only admin
+     @dev Auction must exist
+     @dev Reserve price can only be decreased and never increased
+     @param _nftAddress ERC 721 Address
+     @param _tokenId Token ID of the NFT being auctioned
+     @param _reservePrice New Ether reserve price (WEI value)
+     */
+    function updateAuctionReservePrice(
+        address _nftAddress,
+        uint256 _tokenId,
+        uint256 _reservePrice
+    ) external {
+        Auction storage auction = auctions[_nftAddress][_tokenId];
+        // Store the current reservePrice
+        uint256 currentReserve = auction.reservePrice;
+
+        // Ensures the sender owns the auction and the item is currently in escrow
+        require(
+            IERC721(_nftAddress).ownerOf(_tokenId) == address(this) &&
+                _msgSender() == auction.owner,
+            "Sender must be item owner and NFT must be in escrow"
+        );
+
+        // Ensures the auction hasn't been resulted
+        require(
+            !auction.resulted,
+            "Auction already resulted"
+        );
+
+        // Ensures auction exists
+        require(
+            auction.endTime > 0,
+            "No auction exists"
+        );
+
+        // Ensures the reserve price can only be decreased and never increased
+        require(
+            _reservePrice < currentReserve,
+            "Reserve price can only be decreased"
+        );
+
+        auction.reservePrice = _reservePrice;
+        emit UpdateAuctionReservePrice(
+            _nftAddress,
+            _tokenId,
+            auction.payToken,
+            _reservePrice
+        );
     }
 
     /**


### PR DESCRIPTION
- Removed the withdrawBid functionality and updated createAuction, cancelAuction, and resultAuction functions to account for ownership (escrow) of the NFT being the contract address (address(this))
- Updated resultAuction function to allow auction seller OR winner to resolve the auction
- Added function (resultFailedAuction) to result auctions that have failed to meet auction.reservePrice by auction.endTime, can be called by auction.owner or highestBid.bidder
- Added hard limits to createAuction function to cap auction length at 30 days in total from the _startTimestamp
- Added limits to cancelAuction to ensure the auction has 0 bids before being cancelled (NOTE: _cancelAuction still contains code to refund a highest bidder if found, I left this in as a fail-safe. Although technically _cancelAuction shouldn't be called at all if there's a bidder, so this may be redundant and could be removed to save on gas)
- Removed (auction seller) update functionality (updateAuctionReservePrice, updateAuctionStartTime, updateAuctionEndTime) and event triggers