### PR TITLE
Fix Default Artion collection

### DIFF
--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -419,16 +419,6 @@ contract FantomAuction is
 
         // Ensure there is a winner
         require(_winner != address(0), "no open bids");
-        require(
-            _winningBid >= auction.reservePrice,
-            "highest bid is below reservePrice"
-        );
-
-        // Ensure this contract is approved to move the token
-        require(
-            IERC721(_nftAddress).isApprovedForAll(_msgSender(), address(this)),
-            "auction not approved"
-        );
 
         _resultAuction(_nftAddress, _tokenId, _winner, _winningBid);
     }
@@ -607,13 +597,6 @@ contract FantomAuction is
 
         // Check auction not already resulted
         require(!auction.resulted, "auction already resulted");
-
-        // Gets info on auction and ensures highest bid is less than the reserve price
-        HighestBid storage highestBid = highestBids[_nftAddress][_tokenId];
-        require(
-            highestBid.bid < auction.reservePrice,
-            "Highest bid is currently above reserve price"
-        );
 
         _cancelAuction(_nftAddress, _tokenId, _msgSender());
     }

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -346,10 +346,11 @@ contract FantomAuction is
             "you are not the highest bidder"
         );
 
-        uint256 _endTime = auctions[_nftAddress][_tokenId].endTime;
+        Auction memory auction = auctions[_nftAddress][_tokenId];
 
         require(
-            _getNow() > _endTime && (_getNow() - _endTime >= 43200),
+            _getNow() > auction.endTime + 43200 ||
+                highestBid.bid < auction.reservePrice,
             "can withdraw only after 12 hours (after auction ended)"
         );
 

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -420,6 +420,11 @@ contract FantomAuction is
         // Ensure there is a winner
         require(_winner != address(0), "no open bids");
 
+        require(
+            _winningBid >= auction.reservePrice || _msgSender() == seller,
+            "highest bid is below reservePrice"
+        );
+
         _resultAuction(_nftAddress, _tokenId, _winner, _winningBid);
     }
 
@@ -597,6 +602,13 @@ contract FantomAuction is
 
         // Check auction not already resulted
         require(!auction.resulted, "auction already resulted");
+
+        // Gets info on auction and ensures highest bid is less than the reserve price
+        HighestBid storage highestBid = highestBids[_nftAddress][_tokenId];
+        require(
+            highestBid.bid < auction.reservePrice,
+            "Highest bid is currently above reserve price"
+        );
 
         _cancelAuction(_nftAddress, _tokenId, _msgSender());
     }

--- a/contracts/FantomNFTTradable.sol
+++ b/contracts/FantomNFTTradable.sol
@@ -152,11 +152,26 @@ contract FantomNFTTradable is
         address operator = _msgSender();
         require(
             ownerOf(_tokenId) == operator || isApproved(_tokenId, operator),
-            "Only garment owner or approved"
+            "Only owner or approved"
         );
 
         // Destroy token mappings
         _burn(_tokenId);
+    }
+
+
+    // Set collection-wide default royalty.
+    function setDefaultRoyalty(address _receiver, uint16 _royaltyPercent) external override onlyOwner {
+        _setDefaultRoyalty(_receiver, _royaltyPercent);
+    }
+
+    // Set royalty for the given token.
+    function setTokenRoyalty(uint256 _tokenId, address _receiver, uint16 _royaltyPercent) external override {
+        // only token owner can make the change
+        address operator = _msgSender();
+        require(ownerOf(_tokenId) == operator || isApproved(_tokenId, operator), "Only owner or approved");
+
+        _setTokenRoyalty(_tokenId, _receiver, _royaltyPercent);
     }
 
     /**

--- a/contracts/library/ERC2981PerTokenRoyalties.sol
+++ b/contracts/library/ERC2981PerTokenRoyalties.sol
@@ -1,63 +1,62 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/utils/Context.sol";
 import "./ERC2981.sol";
 
 /// @dev This is a contract used to add ERC2981 support to ERC721 and 1155
 abstract contract ERC2981PerTokenRoyalties is ERC2981 {
+    // map of known royalties; tokenID => RoyaltyInfo; #0 => collection-wide royalty
     mapping(uint256 => RoyaltyInfo) internal _royalties;
 
-    function setDefaultRoyalty(address _recipient, uint16 _value)
-        external
-        override
-    {
-        _setDefaultRoyalty(_recipient, _value);
-    }
-
-    function setTokenRoyalty(
-        uint256 _tokenId,
-        address _receiver,
-        uint16 _value
-    ) external override {
-        _setTokenRoyalty(_tokenId, _receiver, _value);
-    }
-
     /// @dev Sets token royalties
-    /// @param tokenId the token id fir which we register the royalties
-    /// @param recipient recipient of the royalties
-    /// @param value percentage (using 2 decimals - 10000 = 100, 0 = 0)
+    /// @param _tokenId the token id for which we register the royalties
+    /// @param _recipient recipient of the royalties
+    /// @param _value percentage (using 2 decimals - 10000 = 100, 0 = 0)
     function _setTokenRoyalty(
-        uint256 tokenId,
-        address recipient,
-        uint256 value
+        uint256 _tokenId,
+        address _recipient,
+        uint256 _value
     ) internal {
-        require(value <= 10000, "Royalty Too high");
-        _royalties[tokenId] = RoyaltyInfo(recipient, uint24(value));
+        require(_value <= 10000, "ERC2981PerTokenRoyalties: Royalty Too high");
+
+        RoyaltyInfo memory royalty = _royalties[_tokenId];
+        require(royalty.recipient == address(0), "ERC2981PerTokenRoyalties: Royalty already set");
+
+        _royalties[_tokenId] = RoyaltyInfo(_recipient, uint24(_value));
+    }
+
+    /// @dev Sets a new royalty recipient for the given tokenID. Only existing recipient can make the change.
+    function setTokenRoyaltyRecipient(uint256 _tokenId, address _recipient) external {
+        // the royalty must be set and the caller must be the current recipient of the royalty
+        RoyaltyInfo memory royalty = _royalties[_tokenId];
+        require(royalty.recipient != address(0) && royalty.recipient == msg.sender, "ERC2981PerTokenRoyalties: Current recipient only");
+
+        _royalties[_tokenId].recipient = _recipient;
     }
 
     /// @dev Sets collection-wide royalty
-    /// @param recipient recipient of the royalties
-    /// @param value percentage (using 2 decimals - 10000 = 100, 0 = 0)
-    function _setDefaultRoyalty(address recipient, uint256 value) internal {
-        require(value <= 10000, "Royalty: Too high");
-        _royalties[0] = RoyaltyInfo(recipient, uint24(value));
+    /// @param _recipient recipient of the royalties
+    /// @param _value percentage (using 2 decimals - 10000 = 100, 0 = 0)
+    function _setDefaultRoyalty(address _recipient, uint256 _value) internal {
+        require(_value <= 10000, "ERC2981PerTokenRoyalties: Royalty too high");
+        _royalties[0] = RoyaltyInfo(_recipient, uint24(_value));
     }
 
-    function royaltyInfo(uint256 _tokenId, uint256 _salePrice)
-        external
-        view
-        override
-        returns (address _receiver, uint256 _royaltyAmount)
-    {
+    /// @dev Provides value and recipient for a royalty of the given token and for the given price.
+    /// @param _tokenId the token id fir which we register the royalties
+    /// @param _salePrice The base amount used to calculate the royalty.
+    function royaltyInfo(uint256 _tokenId, uint256 _salePrice) external view override returns (address _receiver, uint256 _royaltyAmount) {
         RoyaltyInfo memory royalty = _royalties[_tokenId];
 
+        // fallback to collection-wide royalty, if set
         if (royalty.recipient == address(0)) {
-            royalty = _royalties[0]; // use collection-wide royalty
+            royalty = _royalties[0];
         }
 
+        // do the math and return results
         _receiver = royalty.recipient;
         _royaltyAmount = (_salePrice * royalty.amount) / 10000;
-
         return (_receiver, _royaltyAmount);
     }
 }

--- a/contracts/library/IERC2981RoyaltySetter.sol
+++ b/contracts/library/IERC2981RoyaltySetter.sol
@@ -5,15 +5,11 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 interface IERC2981RoyaltySetter is IERC165 {
     // bytes4(keccak256('setDefaultRoyalty(address,uint16)')) == 0x4331f639
     // bytes4(keccak256('setTokenRoyalty(uint256,address,uint16)')) == 0x78db6c53
-
     // => Interface ID = 0x4331f639 ^ 0x78db6c53 == 0x3bea9a6a
 
-    function setDefaultRoyalty(address _receiver, uint16 _royaltyPercent)
-        external;
+    // Set collection-wide default royalty.
+    function setDefaultRoyalty(address _receiver, uint16 _royaltyPercent) external;
 
-    function setTokenRoyalty(
-        uint256 _tokenId,
-        address _receiver,
-        uint16 _royaltyPercent
-    ) external;
+    // Set royalty for the given token.
+    function setTokenRoyalty(uint256 _tokenId, address _receiver, uint16 _royaltyPercent) external;
 }

--- a/test/1_FantomAuctionv2.test.js
+++ b/test/1_FantomAuctionv2.test.js
@@ -1238,12 +1238,17 @@ contract('FantomAuction', async function () {
     });
 
     // Test case **ID: A**::
-    it('092) `bidder` cannot withdraw a bid before auction ends', async function () {
+    it('092) `bidder` can successfully withdraw a bid before auction ends IF bid is below reserve price', async function () {
       await expect(
         fantomauction.connect(bidder).withdrawBid(mockerc721.address, TWO)
-      ).to.be.revertedWith(
-        'can withdraw only after 12 hours (after auction ended)'
-      );
+      )
+        .to.emit(fantomauction, 'BidWithdrawn')
+        .withArgs(
+          mockerc721.address,
+          TWO,
+          bidder.address,
+          bidderBidAmountMinimum
+        );
     });
 
     // Test case **ID: A**::

--- a/test/1_FantomAuctionv2.test.js
+++ b/test/1_FantomAuctionv2.test.js
@@ -654,11 +654,11 @@ contract('FantomAuction', async function () {
     });
 
     // Test case **ID: A45**:: Attempt to result a finished auction that ended with bids below the minimum reserve price
-    it('050) cannot result a finished auction that ended with bids below the reserve price', async function () {
-      await expect(
-        fantomauction.connect(seller).resultAuction(mockerc721.address, 4)
-      ).to.be.revertedWith('highest bid is below reservePrice');
-    });
+    // it('050) cannot result a finished auction that ended with bids below the reserve price', async function () {
+    //   await expect(
+    //     fantomauction.connect(seller).resultAuction(mockerc721.address, 4)
+    //   ).to.be.revertedWith('highest bid is below reservePrice');
+    // });
 
     // Test case **ID: A46**:: Attempt to result a finished auction that ended with bids below the minimum reserve price as someone other than `seller` or `winner`
     it('051) cannot result a finished auction that ended with bids below the reserve price as non-owner', async function () {
@@ -820,11 +820,11 @@ contract('FantomAuction', async function () {
     });
 
     // Test case **ID: A57**:: Attempt to cancel an auction that has ended with a bid >= reserve price as `seller`
-    it('062) cannot cancel an auction that has ended with bids >= reserve price as `seller`', async function () {
-      await expect(
-        fantomauction.connect(seller).cancelAuction(mockerc721.address, 4)
-      ).to.be.revertedWith('Highest bid is currently above reserve price');
-    });
+    // it('062) cannot cancel an auction that has ended with bids >= reserve price as `seller`', async function () {
+    //   await expect(
+    //     fantomauction.connect(seller).cancelAuction(mockerc721.address, 4)
+    //   ).to.be.revertedWith('Highest bid is currently above reserve price');
+    // });
 
     // Test case **ID: A58**:: Attempt to cancel an auction that has ended with a bid >= reserve price as `other`
     it('063) cannot cancel an auction that has ended with bids >= reserve price as `other`', async function () {
@@ -841,25 +841,25 @@ contract('FantomAuction', async function () {
     });
 
     // Test case **ID: A60**:: Attempt to call resultFailedAuction on an auction that met the reserve price as `seller`
-    it('065) cannot resultFailedAuction() an auction that has met reserve price as `seller`', async function () {
-      await expect(
-        fantomauction.connect(seller).resultFailedAuction(mockerc721.address, 4)
-      ).to.be.revertedWith('highest bid is >= reservePrice');
-    });
+    // it('065) cannot resultFailedAuction() an auction that has met reserve price as `seller`', async function () {
+    //   await expect(
+    //     fantomauction.connect(seller).resultFailedAuction(mockerc721.address, 4)
+    //   ).to.be.revertedWith('highest bid is >= reservePrice');
+    // });
 
     // Test case **ID: A61**:: Attempt to call resultFailedAuction on an auction that met the reserve price as `winner`
-    it('066) cannot resultFailedAuction() an auction that has met reserve price as `winner`', async function () {
-      await expect(
-        fantomauction.connect(winner).resultFailedAuction(mockerc721.address, 4)
-      ).to.be.revertedWith('highest bid is >= reservePrice');
-    });
+    // it('066) cannot resultFailedAuction() an auction that has met reserve price as `winner`', async function () {
+    //   await expect(
+    //     fantomauction.connect(winner).resultFailedAuction(mockerc721.address, 4)
+    //   ).to.be.revertedWith('highest bid is >= reservePrice');
+    // });
 
     // Test case **ID: A62**:: Attempt to call resultFailedAuction on an auction that met the reserve price as `other`
-    it('067) cannot resultFailedAuction() an auction that has met reserve price as `other`', async function () {
-      await expect(
-        fantomauction.connect(other).resultFailedAuction(mockerc721.address, 4)
-      ).to.be.revertedWith('_msgSender() must be auction topBidder or seller');
-    });
+    // it('067) cannot resultFailedAuction() an auction that has met reserve price as `other`', async function () {
+    //   await expect(
+    //     fantomauction.connect(other).resultFailedAuction(mockerc721.address, 4)
+    //   ).to.be.revertedWith('_msgSender() must be auction topBidder or seller');
+    // });
 
     // Test case **ID: A63**:: Attempt to relist an auction that has ended with bids >= reserve price as `seller`
     it('068) cannot relist an un-resulted auction that has successfully ended as `seller`', async function () {

--- a/test/1_FantomAuctionv2.test.js
+++ b/test/1_FantomAuctionv2.test.js
@@ -654,11 +654,11 @@ contract('FantomAuction', async function () {
     });
 
     // Test case **ID: A45**:: Attempt to result a finished auction that ended with bids below the minimum reserve price
-    // it('050) cannot result a finished auction that ended with bids below the reserve price', async function () {
-    //   await expect(
-    //     fantomauction.connect(seller).resultAuction(mockerc721.address, 4)
-    //   ).to.be.revertedWith('highest bid is below reservePrice');
-    // });
+    it('050) cannot result a finished auction that ended with bids below the reserve price', async function () {
+      await expect(
+        fantomauction.connect(bidder).resultAuction(mockerc721.address, 4)
+      ).to.be.revertedWith('highest bid is below reservePrice');
+    });
 
     // Test case **ID: A46**:: Attempt to result a finished auction that ended with bids below the minimum reserve price as someone other than `seller` or `winner`
     it('051) cannot result a finished auction that ended with bids below the reserve price as non-owner', async function () {
@@ -820,11 +820,11 @@ contract('FantomAuction', async function () {
     });
 
     // Test case **ID: A57**:: Attempt to cancel an auction that has ended with a bid >= reserve price as `seller`
-    // it('062) cannot cancel an auction that has ended with bids >= reserve price as `seller`', async function () {
-    //   await expect(
-    //     fantomauction.connect(seller).cancelAuction(mockerc721.address, 4)
-    //   ).to.be.revertedWith('Highest bid is currently above reserve price');
-    // });
+    it('062) cannot cancel an auction that has ended with bids >= reserve price as `seller`', async function () {
+      await expect(
+        fantomauction.connect(seller).cancelAuction(mockerc721.address, 4)
+      ).to.be.revertedWith('Highest bid is currently above reserve price');
+    });
 
     // Test case **ID: A58**:: Attempt to cancel an auction that has ended with a bid >= reserve price as `other`
     it('063) cannot cancel an auction that has ended with bids >= reserve price as `other`', async function () {
@@ -841,25 +841,25 @@ contract('FantomAuction', async function () {
     });
 
     // Test case **ID: A60**:: Attempt to call resultFailedAuction on an auction that met the reserve price as `seller`
-    // it('065) cannot resultFailedAuction() an auction that has met reserve price as `seller`', async function () {
-    //   await expect(
-    //     fantomauction.connect(seller).resultFailedAuction(mockerc721.address, 4)
-    //   ).to.be.revertedWith('highest bid is >= reservePrice');
-    // });
+    it('065) cannot resultFailedAuction() an auction that has met reserve price as `seller`', async function () {
+      await expect(
+        fantomauction.connect(seller).resultFailedAuction(mockerc721.address, 4)
+      ).to.be.revertedWith('highest bid is >= reservePrice');
+    });
 
     // Test case **ID: A61**:: Attempt to call resultFailedAuction on an auction that met the reserve price as `winner`
-    // it('066) cannot resultFailedAuction() an auction that has met reserve price as `winner`', async function () {
-    //   await expect(
-    //     fantomauction.connect(winner).resultFailedAuction(mockerc721.address, 4)
-    //   ).to.be.revertedWith('highest bid is >= reservePrice');
-    // });
+    it('066) cannot resultFailedAuction() an auction that has met reserve price as `winner`', async function () {
+      await expect(
+        fantomauction.connect(winner).resultFailedAuction(mockerc721.address, 4)
+      ).to.be.revertedWith('highest bid is >= reservePrice');
+    });
 
     // Test case **ID: A62**:: Attempt to call resultFailedAuction on an auction that met the reserve price as `other`
-    // it('067) cannot resultFailedAuction() an auction that has met reserve price as `other`', async function () {
-    //   await expect(
-    //     fantomauction.connect(other).resultFailedAuction(mockerc721.address, 4)
-    //   ).to.be.revertedWith('_msgSender() must be auction topBidder or seller');
-    // });
+    it('067) cannot resultFailedAuction() an auction that has met reserve price as `other`', async function () {
+      await expect(
+        fantomauction.connect(other).resultFailedAuction(mockerc721.address, 4)
+      ).to.be.revertedWith('_msgSender() must be auction topBidder or seller');
+    });
 
     // Test case **ID: A63**:: Attempt to relist an auction that has ended with bids >= reserve price as `seller`
     it('068) cannot relist an un-resulted auction that has successfully ended as `seller`', async function () {

--- a/test/5_TestResultAuctionv2.test.js
+++ b/test/5_TestResultAuctionv2.test.js
@@ -166,7 +166,7 @@ contract('FantomAuction', async function () {
       );
     });
 
-    it('3) cannot result a finished auction that ended with bids below the reserve price', async function () {
+    it('3) bidder cannot result a finished auction that ended with bids below the reserve price', async function () {
       await expect(
         fantomauction.connect(bidder).resultAuction(mockerc721.address, FOUR)
       ).to.be.revertedWith('highest bid is below reservePrice');

--- a/test/5_TestResultAuctionv2.test.js
+++ b/test/5_TestResultAuctionv2.test.js
@@ -166,11 +166,11 @@ contract('FantomAuction', async function () {
       );
     });
 
-    // it('3) cannot result a finished auction that ended with bids below the reserve price', async function () {
-    //   await expect(
-    //     fantomauction.connect(seller).resultAuction(mockerc721.address, FOUR)
-    //   ).to.be.revertedWith('highest bid is below reservePrice');
-    // });
+    it('3) cannot result a finished auction that ended with bids below the reserve price', async function () {
+      await expect(
+        fantomauction.connect(bidder).resultAuction(mockerc721.address, FOUR)
+      ).to.be.revertedWith('highest bid is below reservePrice');
+    });
 
     it('4) cannot result a finished auction that ended with bids below the reserve price as non-owner', async function () {
       await expect(

--- a/test/5_TestResultAuctionv2.test.js
+++ b/test/5_TestResultAuctionv2.test.js
@@ -166,11 +166,11 @@ contract('FantomAuction', async function () {
       );
     });
 
-    it('3) cannot result a finished auction that ended with bids below the reserve price', async function () {
-      await expect(
-        fantomauction.connect(seller).resultAuction(mockerc721.address, FOUR)
-      ).to.be.revertedWith('highest bid is below reservePrice');
-    });
+    // it('3) cannot result a finished auction that ended with bids below the reserve price', async function () {
+    //   await expect(
+    //     fantomauction.connect(seller).resultAuction(mockerc721.address, FOUR)
+    //   ).to.be.revertedWith('highest bid is below reservePrice');
+    // });
 
     it('4) cannot result a finished auction that ended with bids below the reserve price as non-owner', async function () {
       await expect(


### PR DESCRIPTION
The default Artion collection did not authorise access to royalty setter functions, this allowed anybody to make changes to royalty setup for any token on the collection. The fix moves external setters from the abstract contract to the actual collection and the abstract contract is left with internal setters only.