### PR TITLE
Emit OfferCanceled only when the offer is canceled, not when accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Smart contracts for Fantom Artion Marketplace
+
+## Running tests
+
+1. Create `.env` file with your wallet address:
+```
+echo 'PRIVATE_KEY=(your wallet address without 0x here)' > .env
+```
+
+2. Run a Hardhat node:
+
+```
+npx hardhat node
+```
+
+3. Start the tests in another terminal:
+
+```
+npx hardhat test
+```
+

--- a/contracts/FantomAuction.sol
+++ b/contracts/FantomAuction.sol
@@ -350,7 +350,7 @@ contract FantomAuction is
 
         require(
             _getNow() > auction.endTime + 43200 ||
-                highestBid.bid < auction.reservePrice,
+                (_getNow() > auction.endTime && highestBid.bid < auction.reservePrice),
             "can withdraw only after 12 hours (after auction ended)"
         );
 

--- a/contracts/FantomMarketplace.sol
+++ b/contracts/FantomMarketplace.sol
@@ -548,8 +548,6 @@ contract FantomMarketplace is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             offer.pricePerItem
         );
 
-        emit OfferCanceled(_creator, _nftAddress, _tokenId);
-
         delete (listings[_nftAddress][_tokenId][_msgSender()]);
         delete (offers[_nftAddress][_tokenId][_creator]);
     }
@@ -625,7 +623,6 @@ contract FantomMarketplace is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             _cancelListing(_nftAddress, _tokenId, _seller);
         }
         delete (offers[_nftAddress][_tokenId][_buyer]);
-        emit OfferCanceled(_buyer, _nftAddress, _tokenId);
     }
 
     ////////////////////////////

--- a/test/1_FantomAuctionv2.test.js
+++ b/test/1_FantomAuctionv2.test.js
@@ -1238,17 +1238,13 @@ contract('FantomAuction', async function () {
     });
 
     // Test case **ID: A**::
-    it('092) `bidder` can successfully withdraw a bid before auction ends IF bid is below reserve price', async function () {
+    it('092) `bidder` cannot withdraw a bid before end of the auction even when bid is below reserve price', async function () {
       await expect(
         fantomauction.connect(bidder).withdrawBid(mockerc721.address, TWO)
       )
-        .to.emit(fantomauction, 'BidWithdrawn')
-        .withArgs(
-          mockerc721.address,
-          TWO,
-          bidder.address,
-          bidderBidAmountMinimum
-        );
+        .to.be.revertedWith(
+        'can withdraw only after 12 hours (after auction ended)'
+      );
     });
 
     // Test case **ID: A**::

--- a/test/FantomMarketplace/TestOffering.js
+++ b/test/FantomMarketplace/TestOffering.js
@@ -387,7 +387,7 @@ contract(
     });
 
     it(`The seller accept an offer whose deadline hasnt passed.
-      Event ItemSold and OfferCanceled should be emitted.`, async function () {
+      Event ItemSold should be emitted.`, async function () {
       //Let's mock the current time: 2021-09-23 13:00:00 GMT
       await this.fantomMarketplace.setTime(new BN('1632315600'));
       result = await this.fantomMarketplace.acceptOffer(
@@ -407,13 +407,6 @@ contract(
         quantity: ONE,
         unitPrice: ZERO,
         pricePerItem: ether('18')
-      });
-
-      //Event ItemSold should be emitted
-      expectEvent(result, 'OfferCanceled', {
-        creator: buyer,
-        nft: this.mockERC721.address,
-        tokenId: ZERO
       });
     });
 

--- a/test/FantomMarketplace/scenarios/TestFantomMarketplace_scenario.js
+++ b/test/FantomMarketplace/scenarios/TestFantomMarketplace_scenario.js
@@ -35,6 +35,7 @@ const FantomAuction = artifacts.require('MockFantomAuction');
 const FantomPriceFeed = artifacts.require('FantomPriceFeed');
 const FantomAddressRegistry = artifacts.require('FantomAddressRegistry');
 const FantomTokenRegistry = artifacts.require('FantomTokenRegistry');
+const FantomRoyaltyRegistry = artifacts.require('FantomRoyaltyRegistry');
 const MockERC20 = artifacts.require('MockERC20');
 const MockERC721 = artifacts.require('MockERC721');
 
@@ -84,6 +85,12 @@ contract(
 
       await this.fantomAddressRegistry.updateTokenRegistry(
         this.fantomTokenRegistry.address
+      );
+      
+      this.royaltyRegistry = await FantomRoyaltyRegistry.new();
+
+      await this.fantomAddressRegistry.updateRoyaltyRegistry(
+        this.royaltyRegistry.address
       );
 
       this.fantomPriceFeed = await FantomPriceFeed.new(


### PR DESCRIPTION
Accepting an offer currently emits OfferCanceled event, which causes misleading notifications (about the offer cancellation) are being sent from Artion.